### PR TITLE
chore(android): 16kB pagesize and edge-to-edge support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,4 @@
 
 dependencies {
-	implementation 'com.giphy.sdk:ui:2.3.0'
+	implementation 'com.giphy.sdk:ui:2.4.0'
 }

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 1.0.0
+version: 1.1.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-giphy
@@ -15,4 +15,4 @@ name: titanium-giphy
 moduleid: ti.giphy
 guid: e85a05bb-b3dd-47f8-90da-74c63d9ab478
 platform: android
-minsdk: 11.0.0
+minsdk: 12.7.0

--- a/android/src/ti/giphy/TitaniumGiphyModule.kt
+++ b/android/src/ti/giphy/TitaniumGiphyModule.kt
@@ -10,15 +10,14 @@
 package ti.giphy
 
 import androidx.appcompat.app.AppCompatActivity
-
 import com.giphy.sdk.core.models.Media
 import com.giphy.sdk.ui.GPHContentType
+import com.giphy.sdk.ui.GPHSettings
 import com.giphy.sdk.ui.Giphy
 import com.giphy.sdk.ui.views.GiphyDialogFragment
-
-import org.appcelerator.kroll.KrollModule
 import org.appcelerator.kroll.KrollDict
 import org.appcelerator.kroll.KrollFunction
+import org.appcelerator.kroll.KrollModule
 import org.appcelerator.kroll.annotations.Kroll
 import org.appcelerator.titanium.TiApplication
 
@@ -31,13 +30,15 @@ class TitaniumGiphyModule: KrollModule() {
 	fun initialize(params: KrollDict) {
 		Giphy.configure(TiApplication.getAppCurrentActivity(), params.getString("apiKey"))
 	}
-	
+
 	@Kroll.method
 	fun showGIFDialog(params: KrollDict) {
 		val callback = params["callback"] as KrollFunction
 		val activity = TiApplication.getAppCurrentActivity() as AppCompatActivity
 
-		val dialog = GiphyDialogFragment.newInstance()
+		val gphSettings = GPHSettings(enableEdgeToEdge = true)
+
+		val dialog = GiphyDialogFragment.newInstance(gphSettings)
 		dialog.gifSelectionListener = object: GiphyDialogFragment.GifSelectionListener {
 			override fun didSearchTerm(term: String) {
 


### PR DESCRIPTION
This PR has following updates:
1. Updates the Giphy Android SDK to latest 2.4.0 (tested fine).
2. Edge to edge support since [GIF Dialog v2.3.17](https://github.com/Giphy/giphy-android-sdk/releases/tag/v2.3.17)
3. 16kB page size support.

[ti.giphy-android-1.1.0.zip](https://github.com/user-attachments/files/24402169/ti.giphy-android-1.1.0.zip)
